### PR TITLE
Another solution for the off hand

### DIFF
--- a/src/main/java/com/tac/guns/event/OffHandEvent.java
+++ b/src/main/java/com/tac/guns/event/OffHandEvent.java
@@ -1,0 +1,63 @@
+package com.tac.guns.event;
+
+import com.tac.guns.item.GunItem;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Hand;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.InputEvent;
+import net.minecraftforge.client.event.RenderHandEvent;
+import net.minecraftforge.event.entity.living.LivingEntityUseItemEvent;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+import static com.tac.guns.item.GunItem.isSingleHanded;
+
+/**
+ * @author Arcomit
+ * @updateDate 2023/7/25
+ */
+@Mod.EventBusSubscriber(modid = "tac",value = Dist.CLIENT)
+public class OffHandEvent {
+
+    @SubscribeEvent
+    public static void renderOffHandEvent(RenderHandEvent event) {
+        if (event.getHand() == Hand.OFF_HAND) {
+            Minecraft mc = Minecraft.getInstance();
+            PlayerEntity player = mc.player;
+            ItemStack mainHand = player.getHeldItemMainhand();
+            ItemStack offHand = event.getItemStack();
+            if (mainHand.getItem() instanceof GunItem) {
+                if (!isSingleHanded(mainHand))
+                {
+                    if (!(offHand.getItem() instanceof GunItem) && !offHand.isEmpty()) {
+                        event.setCanceled(true);//关闭渲染
+                    }
+                }
+            }
+        }
+    }
+
+
+    @SubscribeEvent
+    public static void useOffHandEvent(InputEvent.ClickInputEvent event) {
+        if (event.getHand() == Hand.OFF_HAND) {
+            Minecraft mc = Minecraft.getInstance();
+            PlayerEntity player = mc.player;
+            ItemStack mainHand = player.getHeldItemMainhand();
+            ItemStack offHand = player.getHeldItemOffhand();
+            if (mainHand.getItem() instanceof GunItem) {
+                if (!isSingleHanded(mainHand))
+                {
+                    if (!(offHand.getItem() instanceof GunItem) && !offHand.isEmpty()) {
+                        event.setSwingHand(false);//关闭手臂摆动（不设置false取消事件后仍然会动，跟铁山靠一样）
+                        event.setCanceled(true);//禁用副手
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/tac/guns/item/GunItem.java
+++ b/src/main/java/com/tac/guns/item/GunItem.java
@@ -173,6 +173,8 @@ public class GunItem extends Item implements IColored
 
     public void inventoryTick(ItemStack stack, World worldIn, Entity entityIn, int itemSlot, boolean isSelected) {
         super.inventoryTick(stack, worldIn, entityIn, itemSlot, isSelected);
+        /*
+        建议加个配置选项在这，让玩家选择打开还是不打开这个弹副手物品的功能
         if (isSelected && !worldIn.isRemote)
         {
             if (entityIn instanceof PlayerEntity)
@@ -192,6 +194,7 @@ public class GunItem extends Item implements IColored
                 }
             }
         }
+        */
     }
 
     public static boolean isSingleHanded(ItemStack stack)


### PR DESCRIPTION
Turn off off hand rendering and disable off hand when using dual wield weapons.
当使用双持武器时，不再弹出副手物品而是关闭副手渲染并禁用副手。
(no config,maybe you can provide a setting for players to choose their own off hand solution.)
没有添加配置选项，但也许可以添加个设置供玩家自行选择是否弹出副手物品