### PR TITLE
Fix bug and Sprint related.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,8 @@ archivesBaseName = "tac-a"
 
 
 //name = "tac-a-0.3.0.44-1.16.5"
-
-sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '1.8'
+java.toolchain.languageVersion = JavaLanguageVersion.of(8)
+//sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '1.8'
 
 //sourceSets.main.resources { srcDir 'src/generated/resources' }
 

--- a/src/main/java/com/tac/guns/client/handler/AimingHandler.java
+++ b/src/main/java/com/tac/guns/client/handler/AimingHandler.java
@@ -92,6 +92,7 @@ public class AimingHandler {
         });
     }
 
+    private boolean originalSprint = false;
     @SubscribeEvent
     public void onPlayerTick(TickEvent.PlayerTickEvent event) {
         if (event.phase != TickEvent.Phase.START)
@@ -107,7 +108,13 @@ public class AimingHandler {
             }
         }
         if (isAiming()) {
-            player.setSprinting(false);
+            if (player.isSprinting()){
+                originalSprint = true;
+                player.setSprinting(false);
+            }
+        }else if (originalSprint){
+            originalSprint=false;
+            player.setSprinting(true);
         }
     }
 

--- a/src/main/java/com/tac/guns/client/handler/AimingHandler.java
+++ b/src/main/java/com/tac/guns/client/handler/AimingHandler.java
@@ -106,9 +106,8 @@ public class AimingHandler {
                 this.aimingMap.remove(player);
             }
         }
-        if (this.aiming || this.toggledAim) {
+        if (isAiming()) {
             player.setSprinting(false);
-            Minecraft.getInstance().gameSettings.keyBindSprint.setPressed(false);
         }
     }
 

--- a/src/main/java/com/tac/guns/client/handler/OffHandHandler.java
+++ b/src/main/java/com/tac/guns/client/handler/OffHandHandler.java
@@ -1,7 +1,7 @@
-package com.tac.guns.event;
+package com.tac.guns.client.handler;
 
 import com.mrcrayfish.obfuscate.common.data.SyncedPlayerData;
-import com.tac.guns.Config;
+import com.tac.guns.Reference;
 import com.tac.guns.init.ModSyncedDataKeys;
 import com.tac.guns.item.GunItem;
 import net.minecraft.client.Minecraft;
@@ -20,12 +20,12 @@ import static com.tac.guns.item.GunItem.isSingleHanded;
  * @author Arcomit
  * @updateDate 2023/7/25
  */
-@Mod.EventBusSubscriber(modid = "tac",value = Dist.CLIENT)
-public class OffHandEvent {
+@Mod.EventBusSubscriber(modid = Reference.MOD_ID,value = Dist.CLIENT)
+public class OffHandHandler {
 
     @SubscribeEvent
     public static void renderOffHandEvent(RenderHandEvent event) {
-        if (event.getHand() == Hand.OFF_HAND && Config.COMMON.gameplay.hideLeftHand.get()) {
+        if (event.getHand() == Hand.OFF_HAND) {
             Minecraft mc = Minecraft.getInstance();
             PlayerEntity player = mc.player;
             ItemStack mainHand = player.getHeldItemMainhand();
@@ -44,7 +44,7 @@ public class OffHandEvent {
 
     @SubscribeEvent
     public static void useOffHandEvent(InputEvent.ClickInputEvent event) {
-        if (event.getHand() == Hand.OFF_HAND && Config.COMMON.gameplay.hideLeftHand.get()) {
+        if (event.getHand() == Hand.OFF_HAND) {
             Minecraft mc = Minecraft.getInstance();
             PlayerEntity player = mc.player;
             ItemStack mainHand = player.getHeldItemMainhand();

--- a/src/main/java/com/tac/guns/client/handler/ShootingHandler.java
+++ b/src/main/java/com/tac/guns/client/handler/ShootingHandler.java
@@ -268,6 +268,10 @@ public class  ShootingHandler
                 {
                 	this.shooting = shooting;
                     PacketHandler.getPlayChannel().sendToServer( new MessageShooting( shooting ) );
+                    if (!shooting && originalSprint){
+                        originalSprint=false;
+                        player.setSprinting(true);
+                    }
                 }
             }
             else if(this.shooting)
@@ -352,7 +356,7 @@ public class  ShootingHandler
             }
         }
     }
-
+    private boolean originalSprint = false;
     public void fire(PlayerEntity player, ItemStack heldItem)
     {
         if (magError(player, heldItem)) return;
@@ -366,10 +370,13 @@ public class  ShootingHandler
         if(player.isSpectator())
             return;
 
-        player.setSprinting(false);
         if(GunRenderingHandler.get().sprintTransition != 0) {
             this.shooting = false;
             return;
+        }
+        if (player.isSprinting()){
+            originalSprint = true;
+            player.setSprinting(false);
         }
 
         // CHECK HERE: Restrict the fire rate

--- a/src/main/java/com/tac/guns/client/handler/ShootingHandler.java
+++ b/src/main/java/com/tac/guns/client/handler/ShootingHandler.java
@@ -367,7 +367,6 @@ public class  ShootingHandler
             return;
 
         player.setSprinting(false);
-        Minecraft.getInstance().gameSettings.keyBindSprint.setPressed(false);
         if(GunRenderingHandler.get().sprintTransition != 0) {
             this.shooting = false;
             return;

--- a/src/main/java/com/tac/guns/client/handler/SprintingHandler.java
+++ b/src/main/java/com/tac/guns/client/handler/SprintingHandler.java
@@ -1,0 +1,28 @@
+package com.tac.guns.client.handler;
+
+import com.tac.guns.Reference;
+import com.tac.guns.client.handler.AimingHandler;
+import com.tac.guns.client.handler.ShootingHandler;
+import com.tac.guns.event.ClientSetSprintingEvent;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+/**
+ * @author Arcomit
+ * @updateDate 2023/7/27
+ */
+@Mod.EventBusSubscriber(modid = Reference.MOD_ID,value = Dist.CLIENT)
+public class SprintingHandler {
+    @SubscribeEvent
+    public static void playerSetSprinting(ClientSetSprintingEvent event) {
+        if (event.getSprinting()){
+            if ((AimingHandler.get().isAiming()) || ShootingHandler.get().isShooting()){
+                event.setSprinting(false);
+                //阻止玩家进入疾跑状态（是阻止,而非在setSprinting(true)后再setSprinting(false)）
+                //单击疾跑键进入疾跑只会触发一次setSprinting(true),所以能用setSprinting(false)取消,但是长按疾跑键时会一直触发setSprinting(true)
+                //setSprinting()方法如果为True时就会给玩家加速度,长按疾跑键时在setSprinting(true)后setSprinting(false)的时间差会导致无法减速。
+            }
+        }
+    }
+}

--- a/src/main/java/com/tac/guns/event/ClientSetSprintingEvent.java
+++ b/src/main/java/com/tac/guns/event/ClientSetSprintingEvent.java
@@ -1,0 +1,23 @@
+package com.tac.guns.event;
+
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * @author Arcomit
+ * @updateDate 2023/7/27
+ * @说明：当玩家设置疾跑状态时触发(客户端)
+ */
+public class ClientSetSprintingEvent extends Event {
+    private boolean sprinting;
+    public ClientSetSprintingEvent(boolean sprinting){
+        this.sprinting = sprinting;
+    }
+
+    public void setSprinting(boolean sprinting){
+        this.sprinting = sprinting;
+    }
+
+    public boolean getSprinting(){
+        return sprinting;
+    }
+}

--- a/src/main/java/com/tac/guns/item/GunItem.java
+++ b/src/main/java/com/tac/guns/item/GunItem.java
@@ -1,6 +1,8 @@
 package com.tac.guns.item;
 
 import com.tac.guns.Config;
+import com.tac.guns.client.handler.AimingHandler;
+import com.tac.guns.client.handler.ReloadHandler;
 import com.tac.guns.common.DiscardOffhand;
 import com.tac.guns.common.Gun;
 import com.tac.guns.common.NetworkGunManager;
@@ -170,25 +172,40 @@ public class GunItem extends Item implements IColored
 
     public void inventoryTick(ItemStack stack, World worldIn, Entity entityIn, int itemSlot, boolean isSelected) {
         super.inventoryTick(stack, worldIn, entityIn, itemSlot, isSelected);
-        if (isSelected && !worldIn.isRemote && !Config.COMMON.gameplay.hideLeftHand.get())
-        {
-            if (entityIn instanceof PlayerEntity)
+        if (isSelected){
+            if (stack.getOrCreateTag().get("tac.isSelected") == null){
+                stack.getOrCreateTag().putBoolean("tac.isSelected",true);
+            }
+            if (!worldIn.isRemote && !Config.COMMON.gameplay.hideLeftHand.get())
             {
-                PlayerEntity playerEntity = (PlayerEntity) entityIn;
-                if (!isSingleHanded(stack) && !DiscardOffhand.isSafeTime(playerEntity))
+                if (entityIn instanceof PlayerEntity)
                 {
-                    ItemStack offHand = playerEntity.getHeldItemOffhand();
-                    if (!(offHand.getItem() instanceof GunItem) && !offHand.isEmpty()) {
-                        ItemEntity entity = playerEntity.dropItem(offHand, false);
-                        playerEntity.setHeldItem(Hand.OFF_HAND, ItemStack.EMPTY);
-                        if (entity != null)
-                        {
-                            entity.setNoPickupDelay();
+                    PlayerEntity playerEntity = (PlayerEntity) entityIn;
+                    playerEntity.inventory.currentItem=itemSlot;
+                    if (!isSingleHanded(stack) && !DiscardOffhand.isSafeTime(playerEntity))
+                    {
+                        ItemStack offHand = playerEntity.getHeldItemOffhand();
+                        if (!(offHand.getItem() instanceof GunItem) && !offHand.isEmpty()) {
+                            ItemEntity entity = playerEntity.dropItem(offHand, false);
+                            playerEntity.setHeldItem(Hand.OFF_HAND, ItemStack.EMPTY);
+                            if (entity != null)
+                            {
+                                entity.setNoPickupDelay();
+                            }
                         }
                     }
                 }
             }
+        }else if (stack.getOrCreateTag().get("tac.isSelected") != null){
+            if (worldIn.isRemote){
+                if (AimingHandler.get().isAiming()){
+                    AimingHandler.get().cancelAim();
+                }
+                ReloadHandler.get().setReloading(false);
+            }
+            stack.getOrCreateTag().remove("tac.isSelected");
         }
+
     }
 
     public static boolean isSingleHanded(ItemStack stack)

--- a/src/main/java/com/tac/guns/mixin/client/ClientPlayerEntityMixin.java
+++ b/src/main/java/com/tac/guns/mixin/client/ClientPlayerEntityMixin.java
@@ -1,0 +1,24 @@
+package com.tac.guns.mixin.client;
+
+import com.tac.guns.event.ClientSetSprintingEvent;
+import net.minecraft.client.entity.player.ClientPlayerEntity;
+import net.minecraftforge.eventbus.api.Event;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * @author Arcomit
+ * @updateDate 2023/7/27
+ */
+@Mixin(ClientPlayerEntity.class)
+public class ClientPlayerEntityMixin {
+    @ModifyVariable(at = @At("HEAD"),method = "setSprinting")
+    public boolean setSprinting(boolean sprinting){
+        ClientSetSprintingEvent event = new ClientSetSprintingEvent(sprinting);
+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event);//当玩家疾跑状态发生改变时发送事件
+        return event.getSprinting();
+    }
+}

--- a/src/main/resources/tac.mixins.json
+++ b/src/main/resources/tac.mixins.json
@@ -17,7 +17,8 @@
     "client.InventoryScreenMixin",
     "client.MouseHelperMixin",
     "client.WorldRendererMixin",
-    "client.ShadersFramebufferMixin"
+    "client.ShadersFramebufferMixin",
+    "client.ClientPlayerEntityMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
1.Fix the bug that switching guns does not cancel the aim when using the “toggledAim” mode
1.修复使用"切换开镜"模式切枪不取消开镜的BUG
2.Fix the bug that switching to empty-handed(or other anything) player cannot sprint when using the “toggledAim” mode.
2.修复使用"切换开镜"时开镜切换到空手玩家也无法疾跑的BUG
3.When you press and hold the sprint button, you don't need to press the sprint button again to enter the sprint state after turning off the aim.
3.长按疾跑键时关镜后无需重新按下疾跑键便可再次进入疾跑状态
4.单点疾跑键关键也能自动进入疾跑状态
5.修复按下开火键时即便没有开枪也会退出疾跑状态的BUG