### PR TITLE
Fix bug

### DIFF
--- a/src/main/java/com/tac/guns/client/handler/AimingHandler.java
+++ b/src/main/java/com/tac/guns/client/handler/AimingHandler.java
@@ -107,14 +107,16 @@ public class AimingHandler {
                 this.aimingMap.remove(player);
             }
         }
-        if (isAiming()) {
-            if (player.isSprinting()){
-                originalSprint = true;
-                player.setSprinting(false);
+        if (player == Minecraft.getInstance().player){
+            if (isAiming()) {
+                if (player.isSprinting()){
+                    originalSprint = true;
+                    player.setSprinting(false);
+                }
+            }else if (originalSprint){
+                originalSprint=false;
+                player.setSprinting(true);
             }
-        }else if (originalSprint){
-            originalSprint=false;
-            player.setSprinting(true);
         }
     }
 

--- a/src/main/java/com/tac/guns/client/handler/OffHandHandler.java
+++ b/src/main/java/com/tac/guns/client/handler/OffHandHandler.java
@@ -31,10 +31,10 @@ public class OffHandHandler {
             ItemStack mainHand = player.getHeldItemMainhand();
             ItemStack offHand = event.getItemStack();
             if (mainHand.getItem() instanceof GunItem) {
-                if (!isSingleHanded(mainHand) || SyncedPlayerData.instance().get((PlayerEntity) player, ModSyncedDataKeys.RELOADING))//判断主手是否持有枪械且是否为双手武器
+                if (!isSingleHanded(mainHand) || SyncedPlayerData.instance().get((PlayerEntity) player, ModSyncedDataKeys.RELOADING))
                 {
                     if (!(offHand.getItem() instanceof GunItem) && !offHand.isEmpty()) {
-                        event.setCanceled(true);//关闭渲染
+                        event.setCanceled(true);//Turn off rendering.
                     }
                 }
             }
@@ -50,11 +50,11 @@ public class OffHandHandler {
             ItemStack mainHand = player.getHeldItemMainhand();
             ItemStack offHand = player.getHeldItemOffhand();
             if (mainHand.getItem() instanceof GunItem) {
-                if (!isSingleHanded(mainHand) || SyncedPlayerData.instance().get((PlayerEntity) player, ModSyncedDataKeys.RELOADING))//判断主手是否持有枪械且是否为双手武器
+                if (!isSingleHanded(mainHand) || SyncedPlayerData.instance().get((PlayerEntity) player, ModSyncedDataKeys.RELOADING))
                 {
                     if (!(offHand.getItem() instanceof GunItem) && !offHand.isEmpty()) {
-                        event.setSwingHand(false);//关闭手臂摆动
-                        event.setCanceled(true);//禁用副手
+                        event.setSwingHand(false);//Close arm swing
+                        event.setCanceled(true);//Disable deputies
                     }
                 }
             }

--- a/src/main/java/com/tac/guns/client/handler/SprintingHandler.java
+++ b/src/main/java/com/tac/guns/client/handler/SprintingHandler.java
@@ -19,9 +19,9 @@ public class SprintingHandler {
         if (event.getSprinting()){
             if ((AimingHandler.get().isAiming()) || ShootingHandler.get().isShooting()){
                 event.setSprinting(false);
-                //阻止玩家进入疾跑状态（是阻止,而非在setSprinting(true)后再setSprinting(false)）
-                //单击疾跑键进入疾跑只会触发一次setSprinting(true),所以能用setSprinting(false)取消,但是长按疾跑键时会一直触发setSprinting(true)
-                //setSprinting()方法如果为True时就会给玩家加速度,长按疾跑键时在setSprinting(true)后setSprinting(false)的时间差会导致无法减速。
+                //Prevent the player from entering a Sprinting state (is prevent, not set Sprinting(false) after set Sprinting(true))
+                //Clicking Sprinting to enter the sprint will only trigger set Sprinting(true) once, so we can cancel it with set Sprinting(false), but long pressing the sprint key will always trigger set Sprinting(true).
+                //The set Sprinting() method will give the player acceleration if it is True, and the time difference between set Sprinting(true) and set Sprinting(false) will prevent the player from slowing down.
             }
         }
     }

--- a/src/main/java/com/tac/guns/client/settings/TacKeyBingding.java
+++ b/src/main/java/com/tac/guns/client/settings/TacKeyBingding.java
@@ -1,0 +1,19 @@
+package com.tac.guns.client.settings;
+
+import net.minecraft.client.settings.KeyBinding;
+import net.minecraft.client.util.InputMappings;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+/**
+ * @author Arcomit
+ * @updateDate 2023/7/27
+ */
+public class TacKeyBingding extends KeyBinding {
+    public static final ArrayList<KeyBinding> TAC_KEYBINDS = new ArrayList<>();
+    public TacKeyBingding(String description, int keyCode, String category) {
+        super(description, keyCode, category);
+        TAC_KEYBINDS.add(this);
+    }
+}

--- a/src/main/java/com/tac/guns/client/settings/TacKeyBingding.java
+++ b/src/main/java/com/tac/guns/client/settings/TacKeyBingding.java
@@ -11,9 +11,11 @@ import java.util.HashMap;
  * @updateDate 2023/7/27
  */
 public class TacKeyBingding extends KeyBinding {
-    public static final ArrayList<KeyBinding> TAC_KEYBINDS = new ArrayList<>();
-    public TacKeyBingding(String description, int keyCode, String category) {
+    public static final ArrayList<TacKeyBingding> TAC_KEYBINDS = new ArrayList<>();
+    public boolean isTriggerOtherKey;
+    public TacKeyBingding(String description, int keyCode, String category, boolean isTriggerOtherKey) {
         super(description, keyCode, category);
         TAC_KEYBINDS.add(this);
+        this.isTriggerOtherKey = isTriggerOtherKey;
     }
 }

--- a/src/main/java/com/tac/guns/event/ClientSetSprintingEvent.java
+++ b/src/main/java/com/tac/guns/event/ClientSetSprintingEvent.java
@@ -5,7 +5,7 @@ import net.minecraftforge.eventbus.api.Event;
 /**
  * @author Arcomit
  * @updateDate 2023/7/27
- * @说明：当玩家设置疾跑状态时触发(客户端)
+ * @Note: Triggered when the player sets the sprint state (client)
  */
 public class ClientSetSprintingEvent extends Event {
     private boolean sprinting;

--- a/src/main/java/com/tac/guns/mixin/client/ClientPlayerEntityMixin.java
+++ b/src/main/java/com/tac/guns/mixin/client/ClientPlayerEntityMixin.java
@@ -18,7 +18,7 @@ public class ClientPlayerEntityMixin {
     @ModifyVariable(at = @At("HEAD"),method = "setSprinting")
     public boolean setSprinting(boolean sprinting){
         ClientSetSprintingEvent event = new ClientSetSprintingEvent(sprinting);
-        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event);//当玩家疾跑状态发生改变时发送事件
+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event);//Send an event when the player's sprint state changes
         return event.getSprinting();
     }
 }

--- a/src/main/java/com/tac/guns/mixin/client/KeyBindingMixin.java
+++ b/src/main/java/com/tac/guns/mixin/client/KeyBindingMixin.java
@@ -28,18 +28,24 @@ public class KeyBindingMixin{
 
     @Overwrite
     public static void onTick(InputMappings.Input key) {
-        HashSet<KeyBinding> pressedTacKeyBindings = new HashSet<>();
-        for (KeyBinding tac : TacKeyBingding.TAC_KEYBINDS) {
+        HashSet<TacKeyBingding> pressedTacKeyBindings = new HashSet<>();
+        boolean isTriggerOtherKey = true;
+
+        for (TacKeyBingding tac : TacKeyBingding.TAC_KEYBINDS) {
             if (tac.getKey().equals(key)) {
                 ++((KeyBindingMixin)((Object)tac)).pressTime;
                 pressedTacKeyBindings.add(tac);
+                isTriggerOtherKey = tac.isTriggerOtherKey;
             }
         }//Let the Tac key be triggered first.
-        for (KeyBinding keybinding : HASH.lookupAll(key)) {
-            if (keybinding != null && !pressedTacKeyBindings.contains(keybinding)) {
-                ++((KeyBindingMixin)((Object)keybinding)).pressTime;
-            }
-        }//The same key other than Tac.
+
+        if (isTriggerOtherKey){
+            for (KeyBinding keybinding : HASH.lookupAll(key)) {
+                if (keybinding != null && !pressedTacKeyBindings.contains(keybinding)) {
+                    ++((KeyBindingMixin)((Object)keybinding)).pressTime;
+                }
+            }//The same key other than Tac.
+        }
     }
 
 }

--- a/src/main/java/com/tac/guns/mixin/client/KeyBindingMixin.java
+++ b/src/main/java/com/tac/guns/mixin/client/KeyBindingMixin.java
@@ -1,0 +1,45 @@
+package com.tac.guns.mixin.client;
+
+import com.tac.guns.client.settings.TacKeyBingding;
+import net.minecraft.client.settings.KeyBinding;
+import net.minecraft.client.util.InputMappings;
+import net.minecraftforge.client.settings.KeyBindingMap;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+
+/**
+ * @author Arcomit
+ * @updateDate 2023/7/27
+ * @Notes:Used to resolve KeyBinding collisions.
+ */
+@Mixin(KeyBinding.class)
+public class KeyBindingMixin{
+    @Shadow
+    private int pressTime;
+
+    @Final
+    @Shadow
+    private static KeyBindingMap HASH;
+
+    @Overwrite
+    public static void onTick(InputMappings.Input key) {
+        HashSet<KeyBinding> pressedTacKeyBindings = new HashSet<>();
+        for (KeyBinding tac : TacKeyBingding.TAC_KEYBINDS) {
+            if (tac.getKey().equals(key)) {
+                ++((KeyBindingMixin)((Object)tac)).pressTime;
+                pressedTacKeyBindings.add(tac);
+            }
+        }//Let the Tac key be triggered first.
+        for (KeyBinding keybinding : HASH.lookupAll(key)) {
+            if (keybinding != null && !pressedTacKeyBindings.contains(keybinding)) {
+                ++((KeyBindingMixin)((Object)keybinding)).pressTime;
+            }
+        }//The same key other than Tac.
+    }
+
+}

--- a/src/main/resources/tac.mixins.json
+++ b/src/main/resources/tac.mixins.json
@@ -18,7 +18,8 @@
     "client.MouseHelperMixin",
     "client.WorldRendererMixin",
     "client.ShadersFramebufferMixin",
-    "client.ClientPlayerEntityMixin"
+    "client.ClientPlayerEntityMixin",
+    "client.KeyBindingMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
1.修复多人联机设置玩家疾跑对象错误的bug
1.Fix the bug of setting the wrong object for player's sprint in multiplayer online.
2.将注释修改成英文。
2.Change the comments into English.
3.一个新的解决按键冲突的方案（需要将目前已有的按键全部替换为基于原版的TacKeyBingding，目前尚未替换，仅解决了原版存在的按键冲突问题）
3.A new solution to resolve keybinding conflicts ( need to replace all the existing keys with the Keybingding(TacKeyBingding) based on the Vanilla)