### PR TITLE
Fix “ToggledAim” BUG

### DIFF
--- a/src/main/java/com/tac/guns/entity/ProjectileEntity.java
+++ b/src/main/java/com/tac/guns/entity/ProjectileEntity.java
@@ -400,7 +400,7 @@ public class ProjectileEntity extends Entity implements IEntityAdditionalSpawnDa
                 return;
 
             if (Config.COMMON.gameplay.enableGunGriefing.get() && (block instanceof BreakableBlock || block instanceof PaneBlock) && state.getMaterial() == Material.GLASS) {
-                this.world.destroyBlock(blockRayTraceResult.getPos(), false);
+                this.world.destroyBlock(blockRayTraceResult.getPos(), false,this.shooter);
             }
 
             /*if(modifiedGun.getProjectile().isRicochet() &&

--- a/src/main/java/com/tac/guns/item/GunItem.java
+++ b/src/main/java/com/tac/guns/item/GunItem.java
@@ -198,7 +198,7 @@ public class GunItem extends Item implements IColored
             }
         }else if (stack.getOrCreateTag().get("tac.isSelected") != null){
             if (worldIn.isRemote){
-                if (AimingHandler.get().isAiming()){
+                if (AimingHandler.get().isAiming() || AimingHandler.get().isToggledAim()){
                     AimingHandler.get().cancelAim();
                 }
                 ReloadHandler.get().setReloading(false);

--- a/src/main/java/com/tac/guns/mixin/client/KeyBindingMixin.java
+++ b/src/main/java/com/tac/guns/mixin/client/KeyBindingMixin.java
@@ -8,6 +8,9 @@ import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -26,8 +29,10 @@ public class KeyBindingMixin{
     @Shadow
     private static KeyBindingMap HASH;
 
-    @Overwrite
-    public static void onTick(InputMappings.Input key) {
+    @Inject(method = "onTick",at = @At("HEAD"),cancellable = true)
+    private static void onTick(InputMappings.Input key, CallbackInfo callbackInfo) {
+        callbackInfo.cancel();
+
         HashSet<TacKeyBingding> pressedTacKeyBindings = new HashSet<>();
         boolean isTriggerOtherKey = true;
 


### PR DESCRIPTION
1.修复“切换锁定”下开镜切到空手再切到别的枪不会关镜的BUG
2.Pass shooter in destroyBlock(by BlackScaryZ)
3.KeyMixin改用@Inject。
3.The Key Mixin uses @Inject instead.